### PR TITLE
Exit early if not on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Optionally allow web lookup of title names via the new `-AllowWebLookup` parameter (#3).
 - Provide helpful user suggestions when title names cannot be resolved (#4).
+- Exit early if not on Windows (#5).
 
 ### Changed
 

--- a/Recover-GFWLKeys.ps1
+++ b/Recover-GFWLKeys.ps1
@@ -106,6 +106,12 @@ param(
   [switch]$Help
 )
 
+# Exit early if not on Windows
+if (-not ($env:OS -eq 'Windows_NT')) {
+  Write-Error 'This script is only supported on Windows.'
+  exit 1
+}
+
 if ($Help) {
   Get-Help -Detailed $MyInvocation.MyCommand.Path
   exit 0

--- a/Recover-GFWLKeys.ps1
+++ b/Recover-GFWLKeys.ps1
@@ -108,7 +108,7 @@ param(
 
 # Exit early if not on Windows
 if (-not ($env:OS -eq 'Windows_NT')) {
-  Write-Error 'This script is only supported on Windows.'
+  Write-Error 'FATAL: This script is only supported on Windows.'
   exit 1
 }
 


### PR DESCRIPTION
Add a simple check that will cause the script to exit if not on Windows. This check was designed to be compatible with PowerShell 2.0 and later.