### PR TITLE
Add Rugby League Live to the built-in title cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This improves clarity and aligns with PowerShell best practices for switch parameters.
   - Positional invocation of `-Help` is no longer supported.
 
+### Fixed
+
+- Add Rugby League Live (ID: `484507D3`) to the built-in title cache (#6).
+
 ## [1.2.0] - 2025-08-06
 
 ### Added

--- a/Recover-GFWLKeys.ps1
+++ b/Recover-GFWLKeys.ps1
@@ -234,6 +234,7 @@ $TitleMapJson = @'
   "46450FA4":  "Pro Cycling Manager",
   "46550FA0":  "Jewel Quest 5",
   "46550FA1":  "Family Feud Dream Home",
+  "484507D3":  "Rugby League",
   "48450FA0":  "AFL Live",
   "48450FA1":  "Rugby League Live 2",
   "49470FA1":  "Test Drive Ferrari Racing Legend",


### PR DESCRIPTION
- Add Rugby League Live (ID: `484507D3`) to the JSON title map so that it gets included in the initialized title cache, preventing the need for web lookups.
  - _Note: [Based on marketplace data from Dbox](https://dbox.tools/titles/xbox360/484507D3/), this title is named "Rugby League"._
- This fixes an issue where Dbox data only tagged it for Xbox 360, preventing it from appearing in the original cache.